### PR TITLE
Proposed fix: naming of bpmn-engine-externalmodule-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <build>
     <plugins>
-	  <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
@@ -91,7 +91,7 @@
 
   <dependencyManagement>
     <dependencies>
-	  <!-- Spring BOM -->
+      <!-- Spring BOM -->
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
@@ -99,7 +99,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-	  <!-- Log4j BOM -->
+      <!-- Log4j BOM -->
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
@@ -127,7 +127,7 @@
     </dependency>
     <dependency>
       <groupId>eu.w4</groupId>
-      <artifactId>bpmn-engine-externalmodule</artifactId>
+      <artifactId>bpmn-engine-externalmodule-core</artifactId>
       <version>${version.w4.client}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Naming of dependency externalmodule is aligned with its canonical naming bpmn-engine-externalmodule-core, as found in [W4 maven repository](https://maven.w4store.com).
